### PR TITLE
Updating it to support EMR 6.9.0 emulation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         spark:
+          - 3.3.0
           - 3.2.0
           - 3.1.2
           - 3.1.1
@@ -56,4 +57,4 @@ jobs:
         with:
           push: true
           build_args: SPARK_VERSION=${{ matrix.spark }}
-          tags: 0.5.0-spark${{ matrix.spark }}
+          tags: 0.7.1-spark${{ matrix.spark }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:22.10
 
 # Build time env vars
-ARG SPARK_VERSION
-ENV HADOOP_VERSION 3.2.1
-ENV LIVY_VERSION 0.5.0
+ENV SPARK_VERSION 3.3.0
+ENV HADOOP_VERSION 3.3.3
+ENV LIVY_VERSION 0.7.1
 
 RUN apt-get update -y && apt-get install -y \
     openjdk-8-jre-headless \
@@ -11,10 +11,11 @@ RUN apt-get update -y && apt-get install -y \
     wget \
   && apt-get clean \
   # Apache Livy
-  && wget -q -O /tmp/livy.zip https://archive.apache.org/dist/incubator/livy/$LIVY_VERSION-incubating/livy-$LIVY_VERSION-incubating-bin.zip \
+  && wget -q -O /tmp/livy.zip https://archive.apache.org/dist/incubator/livy/$LIVY_VERSION-incubating/apache-livy-$LIVY_VERSION-incubating-bin.zip \
   && unzip /tmp/livy.zip -d /opt/ \
-  && mv /opt/livy-$LIVY_VERSION-incubating-bin /opt/livy \
-  && mkdir /opt/livy/logs \
+  && mv /opt/apache-livy-$LIVY_VERSION-incubating-bin /opt/livy \
+  && mkdir -p /opt/livy \
+  && mkdir -p /opt/livy/logs \
   # Apache Hadoop
   && wget -q -O /tmp/hadoop.tgz http://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz \
   && tar -xzf /tmp/hadoop.tgz -C /opt/ \
@@ -25,8 +26,8 @@ RUN apt-get update -y && apt-get install -y \
   && tar -xzf /tmp/spark.tgz -C /opt/ \
   && mv /opt/spark-$SPARK_VERSION-bin-without-hadoop /opt/spark \
   && mkdir -p /tmp/spark-events \
-  && mv /opt/hadoop/share/hadoop/tools/lib/aws-java-sdk-bundle-1.11.375.jar /opt/hadoop/share/hadoop/common/aws-java-sdk-bundle-1.11.375.jar \
-  && mv /opt/hadoop/share/hadoop/tools/lib/hadoop-aws-3.2.1.jar /opt/hadoop/share/hadoop/common/hadoop-aws-3.2.1.jar \
+  && mv /opt/hadoop/share/hadoop/tools/lib/aws-java-sdk-bundle-1.11.1026.jar /opt/hadoop/share/hadoop/common/aws-java-sdk-bundle-1.11.1026.jar \
+  && mv /opt/hadoop/share/hadoop/tools/lib/hadoop-aws-3.3.3.jar /opt/hadoop/share/hadoop/common/hadoop-aws-3.3.3.jar \
   && rm -r /opt/hadoop/share/hadoop/tools \
   && rm -r /tmp/*
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ variable.
 ### Usage:
 
 ```bash
-docker run -p 8998:8998 davlum/localemr-container:0.5.0-spark2.4.4
+docker run -p 8998:8998 sumitzet/localemr-container:0.7.1-spark3.3.0
 ```
 
 Visit http://localhost:8998

--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ variable.
 
 ------
 
-### Usage:
-
+### Usage
+```bash
+docker run -p 8998:8998 davlum/localemr-container:0.5.0-spark2.4.4
+```
+### Usage for EMR 6.9.0
 ```bash
 docker run -p 8998:8998 sumitzet/localemr-container:0.7.1-spark3.3.0
 ```


### PR DESCRIPTION
I made changes to get the following version:

- Spark 3.3.0
- Hadoop 3.3.3
- Livy 0.7.1

And, Fixed some bugs arising from this.